### PR TITLE
Check for availability of taxonomy

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -126,6 +126,10 @@ class Extension extends \Bolt\BaseExtension
         // Get all contenttypes (database tables) that have a similar behaves-like-tags taxonomies like $record
         $tables = array();
         foreach ( $contenttypes as $key => $contenttype ) {
+            if (empty($contenttype['taxonomy'])) {
+                continue;
+            }
+
             foreach( $contenttype['taxonomy'] as $taxonomyKey ) {
                 if (in_array( $taxonomyKey, $tagsTaxonomies )) {
                     $tables[] = $contenttype['slug'];


### PR DESCRIPTION
I had a contenttype that had no taxonomy, which resulted in an error (can't foreach over null, after all). This change fixes that by making sure we actually have the key before feeding it to foreach.
